### PR TITLE
docs(getting-started): add delta-rs (Rust/Python) quickstart + links

### DIFF
--- a/packages/delta-site/src/pages/learn/getting-started.md
+++ b/packages/delta-site/src/pages/learn/getting-started.md
@@ -202,6 +202,31 @@ stream2 = spark.readStream.format("delta") \
   .start()
 ```
 
+## Use Delta Lake without Spark (delta-rs: Rust & Python)
+
+Not every workflow needs Apache Spark. You can also use **delta-rs** and its Python bindings to manage Delta tables with full ACID guarantees.
+
+**Docs**
+- **Rust**: https://delta-io.github.io/delta-rs/
+- **Python (deltalake)**: https://pypi.org/project/deltalake/
+
+> delta-rs is a native implementation of the Delta Lake protocol with Python bindings. It supports ACID transactions, time travel, vacuum, and more—no Spark required. See the delta-rs documentation for the latest capabilities and examples.
+
+### Quick Python example
+
+```python
+# pip install deltalake
+from deltalake import DeltaTable, write_deltalake
+import pandas as pd
+
+# Write a Pandas DataFrame to a new Delta table
+df = pd.DataFrame({"id": [1, 2, 3]})
+write_deltalake("tmp/delta_table", df)
+
+# Read it back as a Pandas DataFrame
+dt = DeltaTable("tmp/delta_table")
+print(dt.to_pandas().head())
+
 ## Next Steps
 
 Here are some further resources for learning more about Delta Lake:


### PR DESCRIPTION
## What changed?

- Added a new section **"Use Delta Lake without Spark (delta-rs: Rust & Python)"** to the Getting Started page.
- Provides links to delta-rs documentation (Rust) and the Python `deltalake` package on PyPI.
- Includes a minimal Python quickstart snippet (`write_deltalake`, `DeltaTable`) that new users can run locally.
- Helps surface delta-rs usage as an alternative to Spark for smaller-scale or embedded workflows.

## Why?

- Addresses the need to better surface delta-rs docs (see #361).
- Many new users want to try Delta Lake from Python or Rust without needing Spark.
- Adds clarity and improves discoverability of delta-rs resources.

## Preview impact

- Visitors to [Getting Started](https://delta.io/learn/getting-started/) will now see non-Spark options alongside Spark setup.
- Direct links to delta-rs docs and PyPI help beginners find the right resources faster.

